### PR TITLE
Refactor course selection UX

### DIFF
--- a/Esquema.txt
+++ b/Esquema.txt
@@ -33,7 +33,10 @@ Curso_disennos_experimentales/
 │   │   └── custom.css
 │   ├── js/
 │   │   └── custom.js
-│   └── images/          # Aquí se almacenarán todas las imágenes (png, jpg, etc.)
+│   └── images/
+│       ├── courses/     # Portadas de los cursos (ej. www/images/courses/disenos_estadisticos_v2.jpg)
+│       └── sesiones/    # Miniaturas para cada sesión (ej. www/images/sesiones/disenos_estadisticos_v2_parte_i_sesion_1.jpg)
+│                       # Usa nombres en minúsculas, sin espacios ni acentos.
 ├── data/                # Carpeta para datos de ejemplo o datasets
 ├── README.md
 └── app.R

--- a/R/server.R
+++ b/R/server.R
@@ -1,33 +1,295 @@
 # R/server.R
 server <- function(input, output, session) {
-  observeEvent(input$curso, {
-    req(input$curso)
-    partes <- names(estructura_cursos[[input$curso]])
-    updateRadioButtons(session, "parte", choices = partes, selected = partes[1])
+  sanitize_id <- function(text) {
+    id <- iconv(text, from = "", to = "ASCII//TRANSLIT")
+    if (is.na(id)) {
+      id <- text
+    }
+    id <- tolower(id)
+    id <- gsub("[^a-z0-9]+", "_", id)
+    id <- gsub("(^_|_$)", "", id)
+    id
+  }
+
+  selected_course <- reactiveVal(NULL)
+  selected_part <- reactiveVal(NULL)
+  selected_session <- reactiveVal(NULL)
+
+  observeEvent(input$reset_course, {
+    selected_course(NULL)
+    selected_part(NULL)
+    selected_session(NULL)
   })
 
-  output$sesion_ui <- renderUI({
-    req(input$curso, input$parte)
-    sesiones <- estructura_cursos[[input$curso]][[input$parte]]$sesiones
-    selectInput("sesion", "Sesión:", choices = names(sesiones), selected = names(sesiones)[1])
+  for (curso in names(estructura_cursos)) {
+    local({
+      course_name <- curso
+      course_id <- paste0("course_", sanitize_id(course_name))
+      observeEvent(input[[course_id]], {
+        selected_course(course_name)
+      }, ignoreNULL = TRUE)
+    })
+  }
+
+  observeEvent(selected_course(), {
+    curso <- selected_course()
+    if (is.null(curso)) {
+      selected_part(NULL)
+      selected_session(NULL)
+      return()
+    }
+
+    partes <- names(estructura_cursos[[curso]])
+    if (length(partes) == 0) {
+      selected_part(NULL)
+      selected_session(NULL)
+      return()
+    }
+
+    if (!is.null(selected_part()) && selected_part() %in% partes) {
+      part_actual <- selected_part()
+    } else {
+      part_actual <- partes[1]
+    }
+
+    selected_part(part_actual)
+  }, ignoreNULL = FALSE)
+
+  observeEvent(selected_part(), {
+    curso <- selected_course()
+    parte <- selected_part()
+
+    if (is.null(curso) || is.null(parte)) {
+      selected_session(NULL)
+      return()
+    }
+
+    sesiones <- names(estructura_cursos[[curso]][[parte]]$sesiones)
+    if (length(sesiones) == 0) {
+      selected_session(NULL)
+      return()
+    }
+
+    if (!is.null(selected_session()) && selected_session() %in% sesiones) {
+      sesion_actual <- selected_session()
+    } else {
+      sesion_actual <- sesiones[1]
+    }
+
+    selected_session(sesion_actual)
+  }, ignoreNULL = FALSE)
+
+  observe({
+    curso <- selected_course()
+    parte <- selected_part()
+    if (is.null(curso) || is.null(parte)) {
+      return()
+    }
+
+    partes <- names(estructura_cursos[[curso]])
+    if (!is.null(input$part_selector)) {
+      updateSelectInput(
+        session,
+        "part_selector",
+        choices = partes,
+        selected = parte
+      )
+    }
+  })
+
+  observeEvent(input$part_selector, {
+    req(input$part_selector)
+    if (!identical(selected_part(), input$part_selector)) {
+      selected_part(input$part_selector)
+    }
+  })
+
+  for (curso in names(estructura_cursos)) {
+    partes <- estructura_cursos[[curso]]
+    for (parte in names(partes)) {
+      sesiones <- partes[[parte]]$sesiones
+      for (sesion in names(sesiones)) {
+        local({
+          curso_name <- curso
+          parte_name <- parte
+          sesion_name <- sesion
+          button_id <- paste0(
+            "session_",
+            sanitize_id(paste(curso_name, parte_name, sesion_name))
+          )
+          observeEvent(input[[button_id]], {
+            selected_course(curso_name)
+            selected_part(parte_name)
+            selected_session(sesion_name)
+          }, ignoreNULL = TRUE)
+        })
+      }
+    }
+  }
+
+  output$main_ui <- renderUI({
+    curso_actual <- selected_course()
+
+    if (is.null(curso_actual)) {
+      course_cards <- lapply(names(estructura_cursos), function(nombre_curso) {
+        partes <- estructura_cursos[[nombre_curso]]
+        total_partes <- length(partes)
+        total_sesiones <- sum(vapply(partes, function(x) length(x$sesiones), numeric(1)))
+        course_id <- sanitize_id(nombre_curso)
+        tags$button(
+          id = paste0("course_", course_id),
+          type = "button",
+          class = "course-card action-button",
+          style = sprintf("--card-image: url('images/courses/%s.jpg');", course_id),
+          tags$div(class = "course-card-overlay"),
+          tags$div(
+            class = "course-card-body",
+            tags$span(class = "course-card-kicker", "Curso especializado"),
+            tags$h3(class = "course-card-title", nombre_curso),
+            tags$p(
+              class = "course-card-meta",
+              sprintf("%d parte%s · %d sesión%s", total_partes, ifelse(total_partes == 1, "", "s"), total_sesiones, ifelse(total_sesiones == 1, "", "es"))
+            )
+          )
+        )
+      })
+
+      return(
+        div(
+          class = "landing-page",
+          div(
+            class = "container",
+            div(
+              class = "landing-intro text-center",
+              tags$span(class = "landing-kicker", "Explora el temario digital"),
+              tags$h1(
+                class = "landing-title",
+                "Diseños experimentales para la agro data science"
+              ),
+              tags$p(
+                class = "landing-subtitle",
+                "Selecciona primero un curso para descubrir las sesiones disponibles, diseñadas con un enfoque minimalista y profesional."
+              )
+            ),
+            div(class = "course-grid", course_cards)
+          )
+        )
+      )
+    }
+
+    partes <- names(estructura_cursos[[curso_actual]])
+
+    tagList(
+      div(
+        class = "course-page",
+        div(
+          class = "course-hero",
+          div(
+            class = "container",
+            tags$span(class = "course-hero-kicker", "Curso seleccionado"),
+            tags$h1(class = "course-hero-title", curso_actual),
+            tags$p(
+              class = "course-hero-subtitle",
+              "Elige la parte y la sesión que deseas explorar. Cada módulo combina estadística, agro y ciencia de datos."
+            )
+          )
+        ),
+        div(
+          class = "container course-controls",
+          div(
+            class = "row align-items-center gy-3",
+            div(
+              class = "col-md-6",
+              actionLink(
+                "reset_course",
+                label = tagList(icon("arrow-left"), span(" Elegir otro curso")),
+                class = "reset-course"
+              )
+            ),
+            div(
+              class = "col-md-6 text-md-end",
+              selectInput(
+                "part_selector",
+                "Parte del temario",
+                choices = partes,
+                selected = selected_part(),
+                width = "100%"
+              )
+            )
+          )
+        ),
+        div(
+          class = "container session-grid-container",
+          uiOutput("session_cards")
+        ),
+        div(
+          class = "container session-content-container",
+          uiOutput("contenido_ui")
+        )
+      )
+    )
+  })
+
+  output$session_cards <- renderUI({
+    req(selected_course(), selected_part())
+    curso_actual <- selected_course()
+    parte_actual <- selected_part()
+    sesiones <- estructura_cursos[[curso_actual]][[parte_actual]]$sesiones
+
+    if (length(sesiones) == 0) {
+      return(div(class = "empty-state", "Pronto agregaremos sesiones para esta parte."))
+    }
+
+    cards <- lapply(names(sesiones), function(nombre_sesion) {
+      session_id <- sanitize_id(paste(curso_actual, parte_actual, nombre_sesion))
+      button_id <- paste0("session_", session_id)
+      activa <- identical(selected_session(), nombre_sesion)
+      tags$button(
+        id = button_id,
+        type = "button",
+        class = paste("session-card action-button", if (activa) "active"),
+        style = sprintf("--session-image: url('images/sesiones/%s.jpg');", session_id),
+        tags$div(class = "session-card-overlay"),
+        tags$div(
+          class = "session-card-body",
+          tags$span(class = "session-card-label", parte_actual),
+          tags$h4(class = "session-card-title", nombre_sesion)
+        )
+      )
+    })
+
+    div(class = "session-grid", cards)
   })
 
   output$contenido_ui <- renderUI({
-    req(input$curso, input$parte, input$sesion)
-    info <- obtener_info_sesion(input$curso, input$parte, input$sesion)
+    req(selected_course(), selected_part(), selected_session())
+    info <- obtener_info_sesion(selected_course(), selected_part(), selected_session())
     modulo <- info$module
+
+    contenido <- NULL
 
     if (!is.null(modulo)) {
       ui_fun_name <- paste0(modulo, "UI")
       if (exists(ui_fun_name, mode = "function")) {
         ui_fun <- get(ui_fun_name, mode = "function")
-        return(ui_fun(info$id))
+        contenido <- ui_fun(info$id)
       }
     }
 
+    if (is.null(contenido)) {
+      contenido <- div(
+        class = "alert alert-info",
+        "Contenido próximamente disponible para esta sesión."
+      )
+    }
+
     tagList(
-      h3(input$sesion),
-      div(class = "alert alert-info", "Contenido próximamente disponible para esta sesión.")
+      div(
+        class = "session-detail-header",
+        tags$span(class = "session-detail-pill", selected_part()),
+        tags$h2(class = "session-detail-title", selected_session())
+      ),
+      div(class = "session-detail-body", contenido)
     )
   })
 

--- a/R/ui.R
+++ b/R/ui.R
@@ -1,28 +1,26 @@
 # R/ui.R
 library(shiny)
 library(shinythemes)
+library(bslib)
 
 ui <- fluidPage(
   withMathJax(),
-  theme = bs_theme(bootswatch = "flatly"),
+  theme = bs_theme(
+    version = 5,
+    bootswatch = "flatly",
+    primary = "#2F855A",
+    secondary = "#2B6CB0",
+    success = "#38A169",
+    base_font = font_google("Poppins"),
+    heading_font = font_google("Montserrat"),
+    bg = "#F7FAF2",
+    fg = "#1F2933"
+  ),
   tags$head(
+    tags$link(rel = "preconnect", href = "https://fonts.googleapis.com"),
+    tags$link(rel = "preconnect", href = "https://fonts.gstatic.com", crossorigin = "anonymous"),
     includeCSS("www/css/custom.css"),
     includeScript("www/js/custom.js")
   ),
-
-  titlePanel("📊 Temario de R para Estadística Agrícola"),
-
-  sidebarLayout(
-    sidebarPanel(
-      width = 2,
-      h4("Navegación"),
-      selectInput("curso", "Curso:", choices = names(estructura_cursos), selected = curso_predeterminado),
-      radioButtons("parte", "Parte:", choices = names(estructura_cursos[[curso_predeterminado]]), selected = partes_predeterminadas[1]),
-      uiOutput("sesion_ui")
-    ),
-    mainPanel(
-      width = 10,
-      uiOutput("contenido_ui")
-    )
-  )
+  uiOutput("main_ui")
 )

--- a/www/css/custom.css
+++ b/www/css/custom.css
@@ -1,3 +1,360 @@
+/* ===== Paleta y tipografía principal ===== */
+:root {
+  --agro-green: #2F855A;
+  --deep-forest: #22543D;
+  --agro-light: #F7FAF2;
+  --data-blue: #2B6CB0;
+  --deep-data-blue: #1E3A8A;
+  --charcoal: #1F2933;
+  --card-shadow: 0 24px 40px rgba(34, 84, 61, 0.18);
+}
+
+body {
+  background-color: var(--agro-light);
+  color: var(--charcoal);
+  font-family: 'Poppins', 'Helvetica Neue', Arial, sans-serif;
+}
+
+a,
+.btn-link {
+  color: var(--data-blue);
+}
+
+.landing-page {
+  background: linear-gradient(135deg, rgba(47, 133, 90, 0.12), rgba(43, 108, 176, 0.08));
+  min-height: calc(100vh - 40px);
+  display: flex;
+  align-items: center;
+  padding: 4rem 0;
+}
+
+.landing-intro {
+  max-width: 720px;
+  margin: 0 auto 3rem auto;
+}
+
+.landing-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--deep-forest);
+  background-color: rgba(47, 133, 90, 0.12);
+  border-radius: 999px;
+  padding: 0.4rem 1rem;
+}
+
+.landing-title {
+  font-family: 'Montserrat', 'Poppins', sans-serif;
+  font-size: 2.6rem;
+  font-weight: 700;
+  margin-top: 1rem;
+  color: var(--deep-forest);
+}
+
+.landing-subtitle {
+  font-size: 1.05rem;
+  color: rgba(31, 41, 51, 0.75);
+  margin-top: 1rem;
+}
+
+.course-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2rem;
+  margin-top: 2.5rem;
+}
+
+.course-card {
+  position: relative;
+  border: none;
+  width: 100%;
+  padding: 0;
+  border-radius: 24px;
+  overflow: hidden;
+  cursor: pointer;
+  background-image: linear-gradient(140deg, rgba(34, 84, 61, 0.92), rgba(43, 108, 176, 0.88)), var(--card-image, none);
+  background-size: cover;
+  background-position: center;
+  color: #ffffff;
+  box-shadow: var(--card-shadow);
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
+}
+
+.course-card:hover,
+.course-card:focus {
+  transform: translateY(-10px);
+  box-shadow: 0 32px 60px rgba(34, 84, 61, 0.28);
+  outline: none;
+}
+
+.course-card-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(15, 32, 24, 0.05), rgba(0, 0, 0, 0.45));
+  pointer-events: none;
+}
+
+.course-card-body {
+  position: relative;
+  padding: 2.75rem 2.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  height: 100%;
+  justify-content: flex-end;
+}
+
+.course-card-kicker {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  opacity: 0.85;
+}
+
+.course-card-title {
+  font-family: 'Montserrat', 'Poppins', sans-serif;
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1.3;
+  margin: 0;
+}
+
+.course-card-meta {
+  font-size: 0.95rem;
+  opacity: 0.85;
+  margin: 0;
+}
+
+.course-page {
+  padding-bottom: 4rem;
+}
+
+.course-hero {
+  background: linear-gradient(135deg, rgba(34, 84, 61, 0.95), rgba(27, 63, 107, 0.9));
+  color: #ffffff;
+  padding: 4.5rem 0 3.5rem 0;
+  border-radius: 0 0 48px 48px;
+  box-shadow: 0 30px 60px rgba(34, 84, 61, 0.25);
+}
+
+.course-hero-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  padding: 0.45rem 1.2rem;
+  border-radius: 999px;
+  background-color: rgba(255, 255, 255, 0.18);
+}
+
+.course-hero-title {
+  font-family: 'Montserrat', 'Poppins', sans-serif;
+  font-size: 2.8rem;
+  font-weight: 700;
+  margin-top: 1.5rem;
+}
+
+.course-hero-subtitle {
+  max-width: 680px;
+  font-size: 1.05rem;
+  margin-top: 1rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.course-controls {
+  margin-top: -2.5rem;
+  background: #ffffff;
+  padding: 1.75rem 2rem;
+  border-radius: 20px;
+  box-shadow: 0 15px 35px rgba(27, 63, 107, 0.12);
+}
+
+.reset-course {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: var(--agro-green) !important;
+  text-decoration: none !important;
+}
+
+.reset-course .fa {
+  transition: transform 0.3s ease;
+}
+
+.reset-course:hover .fa {
+  transform: translateX(-4px);
+}
+
+.session-grid-container {
+  margin-top: 3rem;
+}
+
+.session-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.75rem;
+}
+
+.session-card {
+  position: relative;
+  border: none;
+  width: 100%;
+  min-height: 200px;
+  padding: 0;
+  border-radius: 20px;
+  overflow: hidden;
+  cursor: pointer;
+  background-image: linear-gradient(150deg, rgba(34, 84, 61, 0.92), rgba(27, 63, 107, 0.85)), var(--session-image, none);
+  background-size: cover;
+  background-position: center;
+  color: #ffffff;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border 0.3s ease;
+}
+
+.session-card:hover,
+.session-card:focus {
+  transform: translateY(-6px);
+  box-shadow: 0 24px 40px rgba(27, 63, 107, 0.25);
+  outline: none;
+}
+
+.session-card.active {
+  border: 2px solid rgba(255, 255, 255, 0.8);
+  box-shadow: 0 28px 50px rgba(34, 84, 61, 0.35);
+}
+
+.session-card-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(175deg, rgba(15, 32, 24, 0.1), rgba(0, 0, 0, 0.5));
+  pointer-events: none;
+}
+
+.session-card-body {
+  position: relative;
+  padding: 2rem 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  height: 100%;
+  justify-content: flex-end;
+}
+
+.session-card-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 600;
+  opacity: 0.9;
+}
+
+.session-card-title {
+  font-family: 'Montserrat', 'Poppins', sans-serif;
+  font-size: 1.25rem;
+  margin: 0;
+}
+
+.session-content-container {
+  margin-top: 3.5rem;
+  margin-bottom: 2rem;
+}
+
+.session-detail-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.session-detail-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background-color: rgba(43, 108, 176, 0.12);
+  color: var(--data-blue);
+}
+
+.session-detail-title {
+  font-family: 'Montserrat', 'Poppins', sans-serif;
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--deep-forest);
+  margin: 0;
+}
+
+.session-detail-body {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 18px 36px rgba(27, 63, 107, 0.15);
+}
+
+.empty-state {
+  background: rgba(43, 108, 176, 0.08);
+  color: var(--deep-data-blue);
+  padding: 1.5rem;
+  border-radius: 16px;
+  text-align: center;
+  font-weight: 500;
+}
+
+@media (max-width: 991px) {
+  .course-hero {
+    border-radius: 0 0 32px 32px;
+    padding: 3.5rem 0 2.75rem 0;
+  }
+
+  .course-hero-title {
+    font-size: 2.3rem;
+  }
+
+  .course-controls {
+    margin-top: -2rem;
+    padding: 1.5rem 1.75rem;
+  }
+
+  .session-detail-body {
+    padding: 1.75rem;
+  }
+}
+
+@media (max-width: 575px) {
+  .landing-page {
+    padding: 3rem 0;
+  }
+
+  .landing-title {
+    font-size: 2.1rem;
+  }
+
+  .course-card-body {
+    padding: 2.25rem 1.75rem;
+  }
+
+  .session-card-body {
+    padding: 1.75rem 1.5rem;
+  }
+
+  .session-detail-title {
+    font-size: 1.6rem;
+  }
+}
+
 /* Títulos de sesión */
 .session-title {
   margin: 20px 0 15px;


### PR DESCRIPTION
## Summary
- Replace the legacy sidebar layout with a full landing page that highlights each course as a clickable card before entering the content.
- Rework the server logic to drive the new course/parte/sesión navigation flow with reactive values and visual session cards.
- Refresh the theme and custom styles to deliver a professional agro/data science palette and document the new image asset locations.

## Testing
- Not run (not supported in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f6370b264832cbffa15524b0ae3dd)