### PR TITLE
Fix V3 session mapping and adjust CTA styles

### DIFF
--- a/Esquema.txt
+++ b/Esquema.txt
@@ -20,14 +20,14 @@ Curso_disennos_experimentales/
 │           ├── Parte I (IA)/
 │           │   └── session1.R
 │           ├── Parte II (Intermedia)/
-│           │   ├── session1.R
 │           │   ├── session2.R
-│           │   └── session3.R
+│           │   ├── session3.R
+│           │   └── session4.R
 │           └── Parte III (Avanzada)/
-│               ├── session1.R
-│               ├── session2.R
-│               ├── session3.R
-│               └── session4.R
+│               ├── session5.R
+│               ├── session6.R
+│               ├── session7.R
+│               └── session8.R
 ├── www/
 │   ├── css/
 │   │   └── custom.css       # Estilos para landing, navegación, cursos y secciones de proyectos/CV

--- a/R/global.R
+++ b/R/global.R
@@ -59,17 +59,17 @@ estructura_cursos <- list(
     ),
     "Parte II (Intermedia)" = list(
       sesiones = list(
-        "Sesión 1" = list(module = NULL, id = "v3_p2_s1"),
         "Sesión 2" = list(module = NULL, id = "v3_p2_s2"),
-        "Sesión 3" = list(module = NULL, id = "v3_p2_s3")
+        "Sesión 3" = list(module = "session3_v3", id = "v3_p2_s3"),
+        "Sesión 4" = list(module = NULL, id = "v3_p2_s4")
       )
     ),
     "Parte III (Avanzada)" = list(
       sesiones = list(
-        "Sesión 1" = list(module = NULL, id = "v3_p3_s1"),
-        "Sesión 2" = list(module = NULL, id = "v3_p3_s2"),
-        "Sesión 3" = list(module = NULL, id = "v3_p3_s3"),
-        "Sesión 4" = list(module = NULL, id = "v3_p3_s4")
+        "Sesión 5" = list(module = NULL, id = "v3_p3_s5"),
+        "Sesión 6" = list(module = NULL, id = "v3_p3_s6"),
+        "Sesión 7" = list(module = NULL, id = "v3_p3_s7"),
+        "Sesión 8" = list(module = NULL, id = "v3_p3_s8")
       )
     )
   )

--- a/R/modules/Diseños_estadisticos_V3/Parte II (Intermedia)/session3.R
+++ b/R/modules/Diseños_estadisticos_V3/Parte II (Intermedia)/session3.R
@@ -28,7 +28,7 @@
 # - Documentación AIC en R (stats::AIC, extractAIC). :contentReference[oaicite:5]{index=5}
 # ------------------------------------------------------------------------------
 
-session3UI <- function(id) {
+session3_v3UI <- function(id) {
   ns <- NS(id)
   tagList(
     h3(class = "session-title", "Sesión 3: Análisis de Regresión (Lineal y No Lineal)"),
@@ -298,7 +298,7 @@ session3UI <- function(id) {
   )
 }
 
-session3Server <- function(input, output, session) {
+session3_v3Server <- function(input, output, session) {
   ns <- session$ns
 
   # ---------------------------

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Curso_disennos_experimentales/
 │       │   └── Parte II (Intermedia)/session5.R ... session9.R
 │       └── Diseños_estadisticos_V3/
 │           ├── Parte I (IA)/session1.R
-│           ├── Parte II (Intermedia)/session1.R ... session3.R
-│           └── Parte III (Avanzada)/session1.R ... session4.R
+│           ├── Parte II (Intermedia)/session2.R ... session4.R
+│           └── Parte III (Avanzada)/session5.R ... session8.R
 ├── www/
 │   ├── css/custom.css               # Estilos para landing, navegación y cursos
 │   ├── js/custom.js                 # Interacciones personalizadas

--- a/www/css/custom.css
+++ b/www/css/custom.css
@@ -185,6 +185,54 @@ body {
   gap: 1rem;
 }
 
+/* CTA buttons aligned with agro palette */
+.app-shell .btn-primary {
+  background-color: var(--agro-green);
+  border-color: var(--agro-green);
+  color: #fff;
+  box-shadow: 0 10px 20px rgba(34, 84, 61, 0.18);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.app-shell .btn-primary:hover,
+.app-shell .btn-primary:focus {
+  background-color: var(--deep-forest);
+  border-color: var(--deep-forest);
+  color: #fff;
+  transform: translateY(-1px);
+  box-shadow: 0 16px 28px rgba(34, 84, 61, 0.22);
+}
+
+.app-shell .btn-primary:active {
+  background-color: #1b3b2d;
+  border-color: #1b3b2d;
+  transform: translateY(0);
+  box-shadow: 0 8px 16px rgba(34, 84, 61, 0.16);
+}
+
+.app-shell .btn-outline-primary {
+  color: var(--deep-forest);
+  border-color: var(--deep-forest);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.app-shell .btn-outline-primary:hover,
+.app-shell .btn-outline-primary:focus {
+  color: #fff;
+  background-color: var(--deep-forest);
+  border-color: var(--deep-forest);
+  box-shadow: 0 16px 28px rgba(34, 84, 61, 0.18);
+  transform: translateY(-1px);
+}
+
+.app-shell .btn-outline-primary:active {
+  background-color: #1b3b2d;
+  border-color: #1b3b2d;
+  color: #fff;
+  transform: translateY(0);
+  box-shadow: 0 8px 16px rgba(34, 84, 61, 0.12);
+}
+
 .app-shell .hero-stat,
 .app-shell .hero-typing {
   max-width: 100%;


### PR DESCRIPTION
## Summary
- align the V3 course directory and documentation with the new session numbering
- register the V3 intermediate session 3 module so its content renders in the app
- restyle primary and outline CTA buttons to match the green palette

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f8db768fc832c8eadb7e33fb3b992)