### PR TITLE
Simplify session navigation styling

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -495,11 +495,8 @@ server <- function(input, output, session) {
         id = button_id,
         type = "button",
         class = paste("session-card action-button", if (activa) "active"),
-        style = sprintf("--session-image: url('images/sesiones/%s.jpg');", session_id),
-        tags$div(class = "session-card-overlay"),
         tags$div(
           class = "session-card-body",
-          tags$span(class = "session-card-label", parte_actual),
           tags$h4(class = "session-card-title", nombre_sesion)
         )
       )

--- a/www/css/custom.css
+++ b/www/css/custom.css
@@ -535,6 +535,8 @@ body {
   padding: 1.75rem 2rem;
   border-radius: 20px;
   box-shadow: 0 15px 35px rgba(27, 63, 107, 0.12);
+  position: relative;
+  z-index: 2;
 }
 
 .app-shell .reset-course {
@@ -567,62 +569,50 @@ body {
 
 .app-shell .session-card {
   position: relative;
-  border: none;
+  border: 2px solid rgba(34, 84, 61, 0.14);
   width: 100%;
-  padding: 0;
-  border-radius: 22px;
-  overflow: hidden;
+  padding: 1.5rem 1.75rem;
+  border-radius: 18px;
   cursor: pointer;
-  background-image: linear-gradient(140deg, rgba(34, 84, 61, 0.92), rgba(43, 108, 176, 0.88)), var(--session-image, none);
-  background-size: cover;
-  background-position: center;
-  color: #ffffff;
-  box-shadow: 0 18px 38px rgba(34, 84, 61, 0.22);
+  background: #ffffff;
+  color: var(--deep-forest);
+  box-shadow: none;
   transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .app-shell .session-card:hover,
 .app-shell .session-card:focus {
-  transform: translateY(-8px);
-  box-shadow: 0 28px 55px rgba(34, 84, 61, 0.3);
+  transform: translateY(-6px);
+  box-shadow: 0 22px 45px rgba(34, 84, 61, 0.18);
+  border-color: rgba(43, 108, 176, 0.35);
   outline: none;
 }
 
 .app-shell .session-card.active {
-  box-shadow: 0 35px 70px rgba(43, 108, 176, 0.28);
-}
-
-.app-shell .session-card-overlay {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(160deg, rgba(15, 32, 24, 0.05), rgba(0, 0, 0, 0.45));
-  pointer-events: none;
+  background: var(--agro-green);
+  color: #ffffff;
+  border-color: var(--agro-green);
+  box-shadow: 0 26px 55px rgba(47, 133, 90, 0.28);
 }
 
 .app-shell .session-card-body {
   position: relative;
-  padding: 2.4rem 2rem;
+  padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  height: 100%;
-  justify-content: flex-end;
-}
-
-.app-shell .session-card-label {
-  font-size: 0.8rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  font-weight: 600;
-  opacity: 0.85;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  min-height: 84px;
 }
 
 .app-shell .session-card-title {
   font-family: 'Montserrat', 'Poppins', sans-serif;
-  font-size: 1.35rem;
-  font-weight: 700;
-  line-height: 1.3;
+  font-size: 1.1rem;
+  font-weight: 600;
+  line-height: 1.35;
   margin: 0;
+  text-align: center;
 }
 
 .app-shell .session-detail-header {
@@ -658,6 +648,65 @@ body {
   border-radius: 24px;
   padding: 2.5rem;
   box-shadow: 0 20px 40px rgba(27, 63, 107, 0.12);
+}
+
+.app-shell .session-detail-body .bslib-navs-card,
+.app-shell .session-detail-body .card.bslib-navs-card {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+}
+
+.app-shell .session-detail-body .bslib-navs-card > .card-body {
+  padding: 0;
+}
+
+.app-shell .session-detail-body .nav-tabs,
+.app-shell .session-detail-body .nav-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  border-bottom: none;
+  margin-bottom: 1.75rem;
+}
+
+.app-shell .session-detail-body .nav-tabs .nav-link,
+.app-shell .session-detail-body .nav-pills .nav-link {
+  flex: 1 1 220px;
+  text-align: center;
+  border: none;
+  border-radius: 14px;
+  background-color: rgba(47, 133, 90, 0.12);
+  color: var(--deep-forest);
+  font-weight: 600;
+  padding: 0.85rem 1rem;
+  transition: all 0.25s ease;
+}
+
+.app-shell .session-detail-body .nav-tabs .nav-link:hover,
+.app-shell .session-detail-body .nav-tabs .nav-link:focus,
+.app-shell .session-detail-body .nav-pills .nav-link:hover,
+.app-shell .session-detail-body .nav-pills .nav-link:focus {
+  background-color: rgba(43, 108, 176, 0.15);
+  color: var(--deep-data-blue);
+}
+
+.app-shell .session-detail-body .nav-tabs .nav-link.active,
+.app-shell .session-detail-body .nav-pills .nav-link.active {
+  background-color: var(--agro-green);
+  color: #ffffff;
+  box-shadow: 0 16px 32px rgba(47, 133, 90, 0.24);
+}
+
+.app-shell .session-detail-body .tab-content {
+  border: none;
+  padding: 0;
+}
+
+.app-shell .session-detail-body .tab-pane {
+  background: transparent;
+  padding: 0;
 }
 
 .app-shell .empty-state {
@@ -705,10 +754,6 @@ body {
   .app-shell .course-card-body {
     padding: 2.25rem 1.75rem;
   }
-
-  .app-shell .session-card-body {
-    padding: 2.1rem 1.75rem;
-  }
 }
 
 @media (max-width: 768px) {
@@ -747,16 +792,8 @@ body {
     font-size: 0.9rem;
   }
 
-  .app-shell .session-card-body {
-    padding: 1.85rem 1.5rem;
-  }
-
   .app-shell .session-card-title {
-    font-size: 1.2rem;
-  }
-
-  .app-shell .session-card-label {
-    font-size: 0.75rem;
+    font-size: 1.05rem;
   }
 }
 
@@ -771,14 +808,13 @@ body {
     width: 100%;
   }
 
-  .app-shell .course-card-body,
-  .app-shell .session-card-body {
+  .app-shell .course-card-body {
     padding: 1.75rem 1.35rem;
   }
 
   .app-shell .course-card-title,
   .app-shell .session-card-title {
-    font-size: 1.15rem;
+    font-size: 1.05rem;
   }
 
   .app-shell .hero-title {


### PR DESCRIPTION
## Summary
- remove course part labels and background imagery from session cards so they behave as clean navigation buttons
- raise the course controls above the hero overlay and restyle session detail tabs to span the container without heavy borders
- streamline responsive rules for the updated session card layout

## Testing
- not run (UI-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fadcb15dc832cb6d72cf6c0977692)