### PR TITLE
Load project .Renviron before authentication

### DIFF
--- a/R/global.R
+++ b/R/global.R
@@ -7,6 +7,12 @@
 #   * El registro diferido de módulos alojados en `R/modules`.
 #   * La definición de la estructura de cursos consumida por la UI.
 
+# Cargar variables de entorno del proyecto (si existe .Renviron local)
+project_renviron <- file.path(getwd(), ".Renviron")
+if (file.exists(project_renviron)) {
+  readRenviron(project_renviron)
+}
+
 source("R/authentication.R")
 
 # ---- Gestión de paquetes -------------------------------------------------


### PR DESCRIPTION
## Summary
- load the project-level .Renviron file at startup so MongoDB credentials are available before sourcing the authentication module

## Testing
- not run (Rscript is not available in the container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69131894a6b0832cae6346a9c0d3527a)