### PR TITLE
Refine course sidebar layout and session label behaviour

### DIFF
--- a/www/css/custom.css
+++ b/www/css/custom.css
@@ -583,6 +583,10 @@ body {
   margin-top: 3rem;
 }
 
+.app-shell .course-layout .row {
+  --bs-gutter-x: 1.25rem;
+}
+
 /* ===== Sidebar de sesiones ===== */
 .app-shell .course-sidebar {
   background: #ffffff;
@@ -753,6 +757,15 @@ body {
 .app-shell .session-list-label {
   flex: 1 1 auto;
   font-size: 0.95rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.app-shell .session-list-item:focus .session-list-label,
+.app-shell .session-list-item:hover .session-list-label {
+  overflow: visible;
+  white-space: normal;
 }
 
 .app-shell .course-content {
@@ -894,6 +907,22 @@ body {
 
   .app-shell .course-layout {
     margin-top: 2.5rem;
+  }
+}
+
+@media (min-width: 1200px) {
+  .app-shell .course-layout .col-12.col-xl-4 {
+    flex: 0 0 26%;
+    max-width: 26%;
+  }
+
+  .app-shell .course-layout .col-12.col-xl-8 {
+    flex: 0 0 74%;
+    max-width: 74%;
+  }
+
+  .app-shell .course-sidebar {
+    padding: 1.5rem 1.25rem;
   }
 }
 

--- a/www/js/custom.js
+++ b/www/js/custom.js
@@ -1,3 +1,28 @@
+function applySessionLabelTitles(context) {
+  const $context = context ? $(context) : $(document);
+  $context.find('.session-list-item').each(function() {
+    const $item = $(this);
+    const labelText = $item.find('.session-list-label').text().trim();
+    if (labelText && $item.attr('title') !== labelText) {
+      $item.attr('title', labelText);
+    }
+  });
+}
+
+$(document).on('shiny:value', function(event) {
+  if (event.target && event.target.id === 'course_sidebar') {
+    applySessionLabelTitles(event.target);
+  }
+});
+
+$(document).on('mouseenter focus', '.session-list-item', function() {
+  applySessionLabelTitles(this);
+});
+
+$(document).ready(function() {
+  applySessionLabelTitles(document);
+});
+
 $(document).on('click', '.r-code', function() {
   const code = $(this).text().trim();
   navigator.clipboard.writeText(code).then(() => {


### PR DESCRIPTION
## Summary
- reduce the gutter between the study plan sidebar and session content while narrowing the sidebar on extra-large screens
- force session labels into a single line with ellipsis by default and allow them to expand on hover
- add client-side logic to attach tooltips so the full session title is available when hovering the button

## Testing
- not run (UI-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69179ba554e0832ca4561865ca4cddb6)